### PR TITLE
use longer names in the docker example file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
 
-  print:
+  oereb-print:
     networks:
     - print-network
     image: camptocamp/mapfish_print:3.20

--- a/print-apps/oereb/config.yaml
+++ b/print-apps/oereb/config.yaml
@@ -270,14 +270,14 @@ templates:
             httpProcessors:
             - !mapUri    # NEEDED FOR DOCKER ENVIRONMENT
                 mapping:
-                  (https?)://localhost:6543/(.*): "http://wsgi:8080/$2"
+                  (https?)://localhost:6543/(.*): "http://oereb-server:8080/$2"
             - !forwardHeaders
                 headers:
                 - Referer
             - !restrictUris
                 matchers:
                 - !dnsMatch    # NEEDED FOR DOCKER ENVIRONMENT
-                  host: wsgi
+                  host: oereb-server
                   port: 8080
                   reject: false
                 - !ipMatch


### PR DESCRIPTION
Goes along with https://github.com/openoereb/pyramid_oereb/pull/867

Names are (hopefully) clearer, and use a pattern that is accepted by all Tomcat versions.