### PR TITLE
Fix unclickable links GSPOE-20

### DIFF
--- a/print-apps/oereb/legalprovision.jrxml
+++ b/print-apps/oereb/legalprovision.jrxml
@@ -45,7 +45,7 @@
 					<paragraph leftIndent="8" spacingBefore="0" spacingAfter="2"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{TextAtWeb}]]></textFieldExpression>
-				<hyperlinkReferenceExpression><![CDATA[($F{TextAtWeb}.equals("") || $F{TextAtWeb} == null) ? null : $F{TextAtWeb}]]></hyperlinkReferenceExpression>
+				<hyperlinkReferenceExpression><![CDATA[$F{TextAtWeb}]]></hyperlinkReferenceExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
 				<reportElement x="190" y="0" width="110" height="10" uuid="179b7611-a023-4e6c-bd26-1f128b45058d">

--- a/print-apps/oereb/legalprovision.jrxml
+++ b/print-apps/oereb/legalprovision.jrxml
@@ -31,7 +31,7 @@
 			<property name="local_mesure_unitheight" value="pixel"/>
 			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 			<printWhenExpression><![CDATA[$F{Title} != null || $F{OfficialTitle} != null]]></printWhenExpression>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference" hyperlinkTarget="Blank">
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
 				<reportElement positionType="Float" x="0" y="13" width="300" height="12" isPrintWhenDetailOverflows="true" forecolor="#4C8FBA" uuid="010fa648-c53e-4fa5-82ab-ce9a63ed9bd5">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="local_mesure_unity" value="pixel"/>
@@ -47,12 +47,13 @@
 				<textFieldExpression><![CDATA[$F{TextAtWeb}]]></textFieldExpression>
 				<hyperlinkReferenceExpression><![CDATA[($F{TextAtWeb}.equals("") || $F{TextAtWeb} == null) ? null : $F{TextAtWeb}]]></hyperlinkReferenceExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference" hyperlinkTarget="Blank">
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
 				<reportElement x="190" y="0" width="110" height="10" uuid="179b7611-a023-4e6c-bd26-1f128b45058d">
 					<property name="local_mesure_unitheight" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[((ArrayList)$P{TOC_Appendices}.get($P{Theme_Text})).add($F{Title}.equals("") ? $F{OfficialTitle} : $F{Title}) ? "" : ""]]></textFieldExpression>
+				<hyperlinkReferenceExpression><![CDATA[((ArrayList)$P{TOC_Appendices}.get($P{Theme_Text})).add($F{Title}.equals("") ? $F{OfficialTitle} : $F{Title}) ? "" : ""]]></hyperlinkReferenceExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true" bookmarkLevel="2">
 				<reportElement x="0" y="0" width="300" height="13" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" forecolor="#000000" uuid="114a9f86-a715-4eb3-a8a3-5b17bad23c1a">

--- a/print-apps/oereb/topicpage.jrxml
+++ b/print-apps/oereb/topicpage.jrxml
@@ -377,14 +377,15 @@
 					<property name="local_mesure_unitheight" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.leftIndent" value="px"/>
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<printWhenExpression><![CDATA[($F{legend}.equals("") || $F{legend} == null)]]></printWhenExpression>
 				</reportElement>
 				<box topPadding="2" bottomPadding="3"/>
 				<textElement verticalAlignment="Top">
 					<font fontName="Cadastra" size="6"/>
 					<paragraph spacingBefore="0" spacingAfter="2"/>
 				</textElement>
-				<textFieldExpression><![CDATA[($F{legend}.equals("") || $F{legend} == null) ? null : $F{legend}]]></textFieldExpression>
-				<hyperlinkReferenceExpression><![CDATA[($F{legend}.equals("") || $F{legend} == null) ? null : $F{legend}]]></hyperlinkReferenceExpression>
+				<textFieldExpression><![CDATA[$F{legend}]]></textFieldExpression>
+				<hyperlinkReferenceExpression><![CDATA[$F{legend}]]></hyperlinkReferenceExpression>
 			</textField>
 		</band>
 		<band height="47">

--- a/print-apps/oereb/topicpage.jrxml
+++ b/print-apps/oereb/topicpage.jrxml
@@ -370,8 +370,8 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$R{CompleteLegendLabel}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement stretchType="ContainerHeight" mode="Transparent" x="193" y="0" width="300" height="18" forecolor="#4C8FBA" uuid="a70d3e5c-bc32-4737-ba76-60f6cc56a8e2">
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
+				<reportElement stretchType="RelativeToTallestObject" mode="Transparent" x="193" y="0" width="300" height="18" forecolor="#4C8FBA" uuid="a70d3e5c-bc32-4737-ba76-60f6cc56a8e2">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 					<property name="local_mesure_unitheight" value="pixel"/>
@@ -379,11 +379,12 @@
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>
 				<box topPadding="2" bottomPadding="3"/>
-				<textElement verticalAlignment="Top" markup="html">
+				<textElement verticalAlignment="Top">
 					<font fontName="Cadastra" size="6"/>
 					<paragraph spacingBefore="0" spacingAfter="2"/>
 				</textElement>
-				<textFieldExpression><![CDATA[String.format("<a href=\"%1$s\">%1$s</a>", $F{legend})]]></textFieldExpression>
+				<textFieldExpression><![CDATA[($F{legend}.equals("") || $F{legend} == null) ? null : $F{legend}]]></textFieldExpression>
+				<hyperlinkReferenceExpression><![CDATA[($F{legend}.equals("") || $F{legend} == null) ? null : $F{legend}]]></hyperlinkReferenceExpression>
 			</textField>
 		</band>
 		<band height="47">

--- a/print-apps/oereb/topicpage.jrxml
+++ b/print-apps/oereb/topicpage.jrxml
@@ -370,8 +370,8 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$R{CompleteLegendLabel}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference" hyperlinkTarget="Blank">
-				<reportElement stretchType="RelativeToTallestObject" mode="Transparent" x="193" y="0" width="300" height="18" forecolor="#4C8FBA" uuid="a70d3e5c-bc32-4737-ba76-60f6cc56a8e2">
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+				<reportElement stretchType="ContainerHeight" mode="Transparent" x="193" y="0" width="300" height="18" forecolor="#4C8FBA" uuid="a70d3e5c-bc32-4737-ba76-60f6cc56a8e2">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 					<property name="local_mesure_unitheight" value="pixel"/>
@@ -379,12 +379,11 @@
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>
 				<box topPadding="2" bottomPadding="3"/>
-				<textElement verticalAlignment="Top">
+				<textElement verticalAlignment="Top" markup="html">
 					<font fontName="Cadastra" size="6"/>
 					<paragraph spacingBefore="0" spacingAfter="2"/>
 				</textElement>
-				<textFieldExpression><![CDATA[($F{legend}.equals("") || $F{legend} == null) ? null : $F{legend}]]></textFieldExpression>
-				<hyperlinkReferenceExpression><![CDATA[($F{legend}.equals("") || $F{legend} == null) ? null : $F{legend}]]></hyperlinkReferenceExpression>
+				<textFieldExpression><![CDATA[String.format("<a href=\"%1$s\">%1$s</a>", $F{legend})]]></textFieldExpression>
 			</textField>
 		</band>
 		<band height="47">

--- a/print-apps/oereb/topicresponsibleoffice.jrxml
+++ b/print-apps/oereb/topicresponsibleoffice.jrxml
@@ -20,7 +20,7 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$F{Name}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference" hyperlinkTarget="Blank">
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
 				<reportElement positionType="Float" isPrintRepeatedValues="false" x="0" y="13" width="300" height="7" isPrintWhenDetailOverflows="true" forecolor="#4C8FBA" uuid="43b94d8c-f86f-417d-83ec-78e70dcb55f8">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.spacingBefore" value="px"/>

--- a/print-apps/oereb/topicresponsibleoffice.jrxml
+++ b/print-apps/oereb/topicresponsibleoffice.jrxml
@@ -26,14 +26,15 @@
 					<property name="com.jaspersoft.studio.unit.spacingBefore" value="px"/>
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<printWhenExpression><![CDATA[$F{OfficeAtWeb}.equals("") || $F{OfficeAtWeb}== null]]></printWhenExpression>
 				</reportElement>
 				<box topPadding="1"/>
 				<textElement verticalAlignment="Top">
 					<font fontName="Cadastra" size="6"/>
 					<paragraph leftIndent="8" spacingAfter="2"/>
 				</textElement>
-				<textFieldExpression><![CDATA[($F{OfficeAtWeb}.equals("") || $F{OfficeAtWeb}== null) ? null : $F{OfficeAtWeb}]]></textFieldExpression>
-				<hyperlinkReferenceExpression><![CDATA[($F{OfficeAtWeb}.equals("") || $F{OfficeAtWeb} == null) ? null : $F{OfficeAtWeb}]]></hyperlinkReferenceExpression>
+				<textFieldExpression><![CDATA[$F{OfficeAtWeb}]]></textFieldExpression>
+				<hyperlinkReferenceExpression><![CDATA[$F{OfficeAtWeb}]]></hyperlinkReferenceExpression>
 			</textField>
 		</band>
 	</detail>


### PR DESCRIPTION
Fix #38 
This PR:
- makes it possible to open links when clicking on them in all PDF viewers
- cleans up the code for hyperlinks and avoids using long code elements in text fields. Instead `PrintWhenExpressions` are used when possible.


**IMPORTANT NOTE:**
when creating a hyperlink in one of the templates, use the following example:
```
<textField hyperlinkType="Reference">
  <reportElement x="5" y="95" width="300" height="15"/>
  <textFieldExpression class="java.lang.String">"  >> Click here to go to www.google.com"</textFieldExpression>
  <hyperlinkReferenceExpression>"http://www.google.com"</hyperlinkReferenceExpression>
</textField>
```

Do **NOT** add `hyperlinkTarget="Blank"` ! This will break the link for many PDF readers.
http://jasperreports.sourceforge.net/sample.reference/hyperlink/index.html