### PR TITLE
Fix grouped links for Legalprovisions GSPOE-29

### DIFF
--- a/print-apps/oereb/config.yaml
+++ b/print-apps/oereb/config.yaml
@@ -157,7 +157,10 @@ templates:
                     LegalProvisions: !datasource
                         default: []
                         attributes: &lpra
-                            TextAtWeb: !string {} #/definitions/MultilingualUri
+                            TextAtWeb: !datasource
+                                default: []
+                                attributes:
+                                    URL: *optStr #/definitions/MultilingualUri
                             Lawstatus_Code: *optStr
                             Lawstatus_Text: *optStr #/definitions/LocalisedText
                             Number: *optStr #/definitions/ArticleNumber
@@ -334,7 +337,13 @@ templates:
                 outputMapper:
                     jrDataSource: OtherLegendDataSource
             - !createDataSource
-                processors: []
+                processors: 
+                - !createDataSource
+                    processors: []
+                    inputMapper:
+                        TextAtWeb: datasource
+                    outputMapper:
+                        jrDataSource: TextAtWebDataSource
                 inputMapper:
                     LegalProvisions: datasource
                 outputMapper:

--- a/print-apps/oereb/config.yaml
+++ b/print-apps/oereb/config.yaml
@@ -337,7 +337,7 @@ templates:
                 outputMapper:
                     jrDataSource: OtherLegendDataSource
             - !createDataSource
-                processors: 
+                processors: &dsrc
                 - !createDataSource
                     processors: []
                     inputMapper:
@@ -349,13 +349,13 @@ templates:
                 outputMapper:
                     jrDataSource: LegalProvisionsDataSource
             - !createDataSource
-                processors: []
+                processors: *dsrc
                 inputMapper:
                     Hints: datasource
                 outputMapper:
                     jrDataSource: HintsDataSource
             - !createDataSource
-                processors: []
+                processors: *dsrc
                 inputMapper:
                     Laws: datasource
                 outputMapper:

--- a/print-apps/oereb/legalprovision.jrxml
+++ b/print-apps/oereb/legalprovision.jrxml
@@ -21,7 +21,7 @@
 	<parameter name="SUBREPORT_DIR" class="java.lang.String"/>
 	<parameter name="TOC_Appendices" class="java.util.Map"/>
 	<parameter name="Theme_Text" class="java.lang.String"/>
-	<field name="TextAtWeb" class="java.lang.String"/>
+	<field name="TextAtWebDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<field name="Title" class="java.lang.String"/>
 	<field name="OfficialNumber" class="java.lang.String"/>
 	<field name="OfficialTitle" class="java.lang.String"/>
@@ -31,22 +31,17 @@
 			<property name="local_mesure_unitheight" value="pixel"/>
 			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 			<printWhenExpression><![CDATA[$F{Title} != null || $F{OfficialTitle} != null]]></printWhenExpression>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement positionType="Float" x="0" y="13" width="300" height="12" isPrintWhenDetailOverflows="true" forecolor="#4C8FBA" uuid="010fa648-c53e-4fa5-82ab-ce9a63ed9bd5">
-					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-					<property name="local_mesure_unity" value="pixel"/>
+			<subreport>
+				<reportElement mode="Transparent" x="0" y="13" width="300" height="12" isRemoveLineWhenBlank="true" uuid="aea2a6e2-1814-4099-b8e4-6e588177db99">
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="local_mesure_unitheight" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
-					<printWhenExpression><![CDATA[!($F{TextAtWeb}.equals("") || $F{TextAtWeb} == null)]]></printWhenExpression>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>
-				<box topPadding="0" bottomPadding="3"/>
-				<textElement verticalAlignment="Top">
-					<font fontName="Cadastra" size="6"/>
-					<paragraph leftIndent="8" spacingBefore="0" spacingAfter="2"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{TextAtWeb}]]></textFieldExpression>
-				<hyperlinkReferenceExpression><![CDATA[$F{TextAtWeb}]]></hyperlinkReferenceExpression>
-			</textField>
+				<dataSourceExpression><![CDATA[$F{TextAtWebDataSource}]]></dataSourceExpression>
+				<subreportExpression><![CDATA["textatweb.jasper"]]></subreportExpression>
+			</subreport>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
 				<reportElement x="190" y="0" width="110" height="10" uuid="179b7611-a023-4e6c-bd26-1f128b45058d">
 					<property name="local_mesure_unitheight" value="pixel"/>

--- a/print-apps/oereb/legalprovision.jrxml
+++ b/print-apps/oereb/legalprovision.jrxml
@@ -27,21 +27,10 @@
 	<field name="OfficialTitle" class="java.lang.String"/>
 	<field name="Abbreviation" class="java.lang.String"/>
 	<detail>
-		<band height="25">
+		<band height="14">
 			<property name="local_mesure_unitheight" value="pixel"/>
-			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
 			<printWhenExpression><![CDATA[$F{Title} != null || $F{OfficialTitle} != null]]></printWhenExpression>
-			<subreport>
-				<reportElement mode="Transparent" x="0" y="13" width="300" height="12" isRemoveLineWhenBlank="true" uuid="aea2a6e2-1814-4099-b8e4-6e588177db99">
-					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
-					<property name="local_mesure_unitheight" value="pixel"/>
-					<property name="local_mesure_unity" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="px"/>
-					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-				</reportElement>
-				<dataSourceExpression><![CDATA[$F{TextAtWebDataSource}]]></dataSourceExpression>
-				<subreportExpression><![CDATA["textatweb.jasper"]]></subreportExpression>
-			</subreport>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
 				<reportElement x="190" y="0" width="110" height="10" uuid="179b7611-a023-4e6c-bd26-1f128b45058d">
 					<property name="local_mesure_unitheight" value="pixel"/>
@@ -51,7 +40,7 @@
 				<hyperlinkReferenceExpression><![CDATA[((ArrayList)$P{TOC_Appendices}.get($P{Theme_Text})).add($F{Title}.equals("") ? $F{OfficialTitle} : $F{Title}) ? "" : ""]]></hyperlinkReferenceExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true" bookmarkLevel="2">
-				<reportElement x="0" y="0" width="300" height="13" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" forecolor="#000000" uuid="114a9f86-a715-4eb3-a8a3-5b17bad23c1a">
+				<reportElement stretchType="ContainerHeight" x="0" y="0" width="300" height="13" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" forecolor="#000000" uuid="114a9f86-a715-4eb3-a8a3-5b17bad23c1a">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="local_mesure_unity" value="pixel"/>
 					<property name="local_mesure_unitheight" value="pixel"/>
@@ -63,6 +52,20 @@
 				</textElement>
 				<textFieldExpression><![CDATA[($F{Title}.equals("") || $F{Title} == null ? ($F{OfficialTitle}.equals("") || $F{OfficialTitle} == null ? "-" :   $F{OfficialTitle}): $F{Title}) + (($F{Abbreviation}.equals("") || $F{Abbreviation} == null) ? "" : " (" + $F{Abbreviation} + ")") + (($F{OfficialNumber}.equals("") || $F{OfficialNumber} == null) ? "" : ", " + $F{OfficialNumber})]]></textFieldExpression>
 			</textField>
+		</band>
+		<band height="9">
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<subreport>
+				<reportElement stretchType="ContainerBottom" mode="Transparent" x="0" y="0" width="300" height="9" isRemoveLineWhenBlank="true" uuid="aea2a6e2-1814-4099-b8e4-6e588177db99">
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<dataSourceExpression><![CDATA[$F{TextAtWebDataSource}]]></dataSourceExpression>
+				<subreportExpression><![CDATA["textatweb.jasper"]]></subreportExpression>
+			</subreport>
 		</band>
 		<band height="15">
 			<property name="local_mesure_unitheight" value="pixel"/>

--- a/print-apps/oereb/textatweb.jrxml
+++ b/print-apps/oereb/textatweb.jrxml
@@ -5,19 +5,20 @@
 	<parameter name="SUBREPORT_DIR" class="java.lang.String"/>
 	<field name="URL" class="java.lang.String"/>
 	<detail>
-		<band height="12">
+		<band height="9">
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement positionType="Float" x="0" y="0" width="300" height="12" isPrintWhenDetailOverflows="true" forecolor="#4C8FBA" uuid="010fa648-c53e-4fa5-82ab-ce9a63ed9bd5">
-					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				<reportElement positionType="Float" stretchType="ContainerBottom" x="0" y="0" width="300" height="9" isPrintWhenDetailOverflows="true" forecolor="#4C8FBA" uuid="010fa648-c53e-4fa5-82ab-ce9a63ed9bd5">
 					<property name="local_mesure_unity" value="pixel"/>
 					<property name="local_mesure_unitheight" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<printWhenExpression><![CDATA[!($F{URL}.equals("") || $F{URL} == null)]]></printWhenExpression>
 				</reportElement>
 				<box topPadding="0" bottomPadding="3"/>
 				<textElement verticalAlignment="Top">
 					<font fontName="Cadastra" size="6"/>
+					<paragraph leftIndent="8" spacingBefore="0" spacingAfter="2"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{URL}]]></textFieldExpression>
 				<hyperlinkReferenceExpression><![CDATA[$F{URL}]]></hyperlinkReferenceExpression>

--- a/print-apps/oereb/textatweb.jrxml
+++ b/print-apps/oereb/textatweb.jrxml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.10.0.final using JasperReports Library version 6.10.0-unknown  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="topicmapboxlegend" pageWidth="299" pageHeight="20" columnWidth="273" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="6477891d-f5c5-456f-a115-e91b2a2768c6">
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
+	<parameter name="SUBREPORT_DIR" class="java.lang.String"/>
+	<field name="URL" class="java.lang.String"/>
+	<detail>
+		<band height="12">
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
+				<reportElement positionType="Float" x="0" y="0" width="300" height="12" isPrintWhenDetailOverflows="true" forecolor="#4C8FBA" uuid="010fa648-c53e-4fa5-82ab-ce9a63ed9bd5">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+				</reportElement>
+				<box topPadding="0" bottomPadding="3"/>
+				<textElement verticalAlignment="Top">
+					<font fontName="Cadastra" size="6"/>
+					<paragraph leftIndent="8" spacingBefore="0" spacingAfter="2"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{URL}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+</jasperReport>

--- a/print-apps/oereb/textatweb.jrxml
+++ b/print-apps/oereb/textatweb.jrxml
@@ -13,13 +13,14 @@
 					<property name="local_mesure_unity" value="pixel"/>
 					<property name="local_mesure_unitheight" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+					<printWhenExpression><![CDATA[!($F{URL}.equals("") || $F{URL} == null)]]></printWhenExpression>
 				</reportElement>
 				<box topPadding="0" bottomPadding="3"/>
 				<textElement verticalAlignment="Top">
 					<font fontName="Cadastra" size="6"/>
-					<paragraph leftIndent="8" spacingBefore="0" spacingAfter="2"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{URL}]]></textFieldExpression>
+				<hyperlinkReferenceExpression><![CDATA[$F{URL}]]></hyperlinkReferenceExpression>
 			</textField>
 		</band>
 	</detail>

--- a/print-apps/oereb/topicpage.jrxml
+++ b/print-apps/oereb/topicpage.jrxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.6.0.final using JasperReports Library version 6.6.0  -->
+<!-- Created with Jaspersoft Studio version 6.10.0.final using JasperReports Library version 6.10.0-unknown  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Topicpage" pageWidth="595" pageHeight="842" whenNoDataType="AllSectionsNoDetail" columnWidth="493" leftMargin="51" rightMargin="51" topMargin="28" bottomMargin="20" uuid="3664412a-b6c6-4e1c-8c14-6c4af7e6efc2">
 	<property name="net.sf.jasperreports.print.create.bookmarks" value="true"/>
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
@@ -29,7 +29,7 @@
 		</queryString>
 		<field name="OfficialTitle" class="java.lang.String"/>
 		<field name="Title" class="java.lang.String"/>
-		<field name="TextAtWeb" class="java.lang.String"/>
+		<field name="TextAtWebDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	</subDataset>
 	<subDataset name="LegalProvisionsDataSource" uuid="5f77d94f-5f61-48d9-ad0a-eba04cb7a940">
 		<queryString>
@@ -37,7 +37,7 @@
 		</queryString>
 		<field name="OfficialTitle" class="java.lang.String"/>
 		<field name="Title" class="java.lang.String"/>
-		<field name="TextAtWeb" class="java.lang.String"/>
+		<field name="TextAtWebDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	</subDataset>
 	<subDataset name="HintsDataSource" uuid="15455023-00f1-4b7d-9e91-d37b6e6ad77c">
 		<queryString>
@@ -45,7 +45,7 @@
 		</queryString>
 		<field name="OfficialTitle" class="java.lang.String"/>
 		<field name="Title" class="java.lang.String"/>
-		<field name="TextAtWeb" class="java.lang.String"/>
+		<field name="TextAtWebDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	</subDataset>
 	<subDataset name="LawsDataSource" uuid="9afae2eb-c0ac-49d8-b3c8-b03abc22c889">
 		<queryString>
@@ -53,7 +53,7 @@
 		</queryString>
 		<field name="OfficialTitle" class="java.lang.String"/>
 		<field name="Title" class="java.lang.String"/>
-		<field name="TextAtWeb" class="java.lang.String"/>
+		<field name="TextAtWebDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	</subDataset>
 	<subDataset name="ResponsibleOfficeDataSource" uuid="9afae2eb-c0ac-49d8-b3c8-b03abc22c889">
 		<queryString>


### PR DESCRIPTION
This PR fixes links that get group together. It uses a new data-source for `TextAtWeb` so that it is possible to passe multiple `TextAtWeb` elements for one Title and each link have its own hyperlink destination.

TODO Fix the template for the following topics:

- [x] LegalProvisioions
- [x] Gesetzliche Grundlagen
- [x] Weitere Informationen und Hinweise
- [x] Zuständige Stelle

TOTEST:

To test this PR you need:

- the modified print proxy code from PR  https://github.com/openoereb/pyramid_oereb/pull/970
- set [group_legal_provisions](https://github.com/openoereb/pyramid_oereb/blob/master/docker/config.yaml.mako#L114) to true