### PR TITLE
Treat page break issues in topicpage GEO-2795

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ ensure the following:
 
 1. verify that Java is installed in version 8 or later on your system (required by this MapFish-Print version)
 2. add the Cadastra font package to your print app, by creating a folder ``WEB-INF/lib`` in the app
-  and copying the Cadastra.jar file to it. 
-You can find a copy of this package 
+  and copying the Cadastra.jar file to it.
+You can find a copy of this package
 [in the MapFish-Print repository](https://github.com/mapfish/mapfish-print/tree/master/core/docker/usr/local/tomcat/webapps/ROOT/WEB-INF/lib).
 
 ## Running local tests:
@@ -22,16 +22,16 @@ To run a local instance of mapfish-print (in docker) with the oereb templates, d
 
 ``make serve``
 
-### Prerequisites for running local tests: 
+### Prerequisites for running local tests:
 make sure docker is installed. In addition, if you have not done
 this before, you need to declare the ``print-network`` for docker,
 so that your local ``pyramid_oereb`` docker container can access
-your local ``print`` container, as follows: 
+your local ``print`` container, as follows:
 ``sudo docker network create print-network``
 
 ## Project history
 This subproject was created consequently of
 [Issue 459](https://github.com/openoereb/pyramid_oereb/issues/459).
-Access the history of the templates by using this 
+Access the history of the templates by using this
 [openoereb/pyramid_oereb commit](https://github.com/openoereb/pyramid_oereb/commit/352970f3504385a462797dab7de30fd00896b922),
 which deleted the templates there as a starting point.

--- a/print-apps/oereb/legalprovision.jrxml
+++ b/print-apps/oereb/legalprovision.jrxml
@@ -56,7 +56,7 @@
 		<band height="9">
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
 			<subreport>
-				<reportElement stretchType="ContainerBottom" mode="Transparent" x="0" y="0" width="300" height="9" isRemoveLineWhenBlank="true" uuid="aea2a6e2-1814-4099-b8e4-6e588177db99">
+				<reportElement stretchType="ContainerBottom" mode="Transparent" x="0" y="0" width="300" height="9" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="aea2a6e2-1814-4099-b8e4-6e588177db99">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="local_mesure_unitheight" value="pixel"/>
 					<property name="local_mesure_unity" value="pixel"/>
@@ -66,25 +66,6 @@
 				<dataSourceExpression><![CDATA[$F{TextAtWebDataSource}]]></dataSourceExpression>
 				<subreportExpression><![CDATA["textatweb.jasper"]]></subreportExpression>
 			</subreport>
-		</band>
-		<band height="15">
-			<property name="local_mesure_unitheight" value="pixel"/>
-			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-			<staticText>
-				<reportElement isPrintRepeatedValues="false" x="0" y="0" width="300" height="15" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="54a11828-13b7-448c-a1ee-27dfaeb28bd0">
-					<property name="local_mesure_unitx" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
-					<property name="local_mesure_unity" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
-					<property name="local_mesure_unitheight" value="pixel"/>
-					<printWhenExpression><![CDATA[($F{Title} == null || $F{Title}.equals("")) && ($F{OfficialTitle} == null || $F{OfficialTitle}.equals(""))]]></printWhenExpression>
-				</reportElement>
-				<box bottomPadding="3"/>
-				<textElement markup="html"/>
-				<text><![CDATA[&mdash;]]></text>
-			</staticText>
 		</band>
 	</detail>
 </jasperReport>

--- a/print-apps/oereb/topicpage.jrxml
+++ b/print-apps/oereb/topicpage.jrxml
@@ -408,7 +408,7 @@
 				<subreportExpression><![CDATA["legalprovision.jasper"]]></subreportExpression>
 			</subreport>
 			<textField>
-				<reportElement stretchType="RelativeToTallestObject" x="0" y="28" width="493" height="18" uuid="bc365be9-27bf-41cb-8f51-82a3b7af3eda">
+				<reportElement positionType="Float" stretchType="ContainerBottom" x="0" y="28" width="493" height="18" isPrintWhenDetailOverflows="true" uuid="bc365be9-27bf-41cb-8f51-82a3b7af3eda">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 					<property name="local_mesure_unitheight" value="pixel"/>
 					<property name="local_mesure_unity" value="pixel"/>
@@ -448,7 +448,7 @@
 				<subreportExpression><![CDATA["legalprovision.jasper"]]></subreportExpression>
 			</subreport>
 			<textField>
-				<reportElement stretchType="RelativeToTallestObject" x="0" y="0" width="493" height="18" uuid="8f553e43-b8da-410e-b472-0116a8793b6d">
+				<reportElement positionType="Float" stretchType="ContainerBottom" x="0" y="0" width="493" height="18" isPrintWhenDetailOverflows="true" uuid="8f553e43-b8da-410e-b472-0116a8793b6d">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="local_mesure_unitheight" value="pixel"/>
@@ -489,7 +489,7 @@
 				<subreportExpression><![CDATA["legalprovision.jasper"]]></subreportExpression>
 			</subreport>
 			<textField isStretchWithOverflow="true">
-				<reportElement stretchType="RelativeToTallestObject" x="0" y="0" width="493" height="18" uuid="94ac5c43-32f0-4769-ba84-96a56cb660b6">
+				<reportElement positionType="Float" stretchType="ContainerBottom" x="0" y="0" width="493" height="18" isPrintWhenDetailOverflows="true" uuid="94ac5c43-32f0-4769-ba84-96a56cb660b6">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
@@ -527,7 +527,7 @@
 				<subreportExpression><![CDATA["topicresponsibleoffice.jasper"]]></subreportExpression>
 			</subreport>
 			<textField>
-				<reportElement stretchType="RelativeToTallestObject" x="0" y="0" width="493" height="30" uuid="c4523b24-d156-4e85-bbec-36a92dd6c8b3">
+				<reportElement positionType="Float" stretchType="ContainerBottom" x="0" y="0" width="493" height="30" isPrintWhenDetailOverflows="true" uuid="c4523b24-d156-4e85-bbec-36a92dd6c8b3">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 				</reportElement>


### PR DESCRIPTION
Fixes #36
This proposes a fix for text and line element disappearing when a page break occurs due to text overflow.

For testing purposes more data is added in https://github.com/openoereb/pyramid_oereb/pull/973

**NOTE:**
The title of the band that breaks on to a new page is printed twice. Once on the old page and on the new one. I left it like this as it was the fastest and easiest way to fix the issue. It this is not wanted I think there is a way to fix it but this would mean to take apart the text field and the line (which is at the moment integrated in the text field). I think it is not the best solution. It would be better to separate the element but it can be done in an other PR. It will likely take a couple of hours.