### PR TITLE
add -d option to 'make serve'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ git-attributes:
 
 .PHONY: serve
 serve:
-	docker-compose up --build --remove-orphans
+	docker-compose up --build --remove-orphans -d


### PR DESCRIPTION
all is in the title, I personally prefer when I make a `make serve` and I get the terminal back.

If one want the logs in real-time it is still possible to use `docker-compose logs -f oereb-print`.