### PR TITLE
Add environment variable to override the maximum request length

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       LOG_LEVEL: INFO
       CATALINA_OPTS: >-
         -Xmx512M
+        -Dmapfish.maxContentLength=4194304
     volumes:
       - ./print-apps:/usr/local/tomcat/webapps/ROOT/print-apps:ro
     ports:


### PR DESCRIPTION
Add the environment variable to override the allowed maximum length of requests. Set higher than the default (for big parcels)