### PR TITLE
Use more general mapfish_print image version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   oereb-print:
     networks:
     - print-network
-    image: camptocamp/mapfish_print:3.28.1
+    image: camptocamp/mapfish_print:3.28
     environment:
       PRINT_YAML_MAX_ALIASES: 200
       LOG_LEVEL: INFO


### PR DESCRIPTION
Use more general mapfish_print image version, in order to get security update images