### PR TITLE
Add area lable fix V2

### DIFF
--- a/print-apps/oereb/mainRealestateInfo.jrxml
+++ b/print-apps/oereb/mainRealestateInfo.jrxml
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.17.0.final using JasperReports Library version 6.17.0-6d93193241dd8cc42629e188b94f9e0bc5722efd  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="topicmapboxlegend" pageWidth="493" pageHeight="120" whenNoDataType="AllSectionsNoDetail" columnWidth="493" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="6477891d-f5c5-456f-a115-e91b2a2768c6">
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
+	<style name="Default" isDefault="true" fontName="Cadastra" fontSize="8"/>
+	<parameter name="RealEstate_Number" class="java.lang.String"/>
+	<parameter name="RealEstate_Type_Text" class="java.lang.String"/>
+	<parameter name="RealEstate_EGRID" class="java.lang.String"/>
+	<parameter name="RealEstate_MunicipalityName" class="java.lang.String"/>
+	<parameter name="RealEstate_MunicipalityCode" class="java.lang.String"/>
+	<parameter name="RealEstate_LandRegistryArea" class="java.lang.String"/>
+	<parameter name="RealEstate_SubunitOfLandRegister" class="java.lang.String"/>
+	<parameter name="UpdateDateCS" class="java.lang.String"/>
+	<parameter name="Display_Certification" class="java.lang.Boolean"/>
+	<parameter name="Display_RealEstate_SubunitOfLandRegister" class="java.lang.Boolean"/>
+	<parameter name="SUBREPORT_DIR" class="java.lang.String"/>
+	<title>
+		<band height="119">
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<textField>
+				<reportElement x="0" y="0" width="493" height="17" uuid="fd056aa4-9b94-4ffc-a257-fc931f99e7a8">
+					<property name="com.jaspersoft.studio.unit.x" value="cm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<box bottomPadding="2">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{RealEstateLabel}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="193" y="0" width="300" height="17" uuid="28b56fef-274e-45f3-853c-5d9c52f33f71">
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{RealEstate_Number}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="0" y="17" width="493" height="17" uuid="e8c53976-1abf-4773-8c8b-09c29ecbdfbd">
+					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.width" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+				</reportElement>
+				<box bottomPadding="1">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{RealEstateTypeLabel}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="193" y="17" width="300" height="17" isPrintWhenDetailOverflows="true" uuid="5cfead8a-bdfe-4164-a938-c8829d5f6bc7">
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle" markup="styled">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{RealEstate_Type_Text}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Default" x="0" y="34" width="493" height="17" uuid="006f5580-5e3e-4f4a-a684-b9faa840fdf4">
+					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.width" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<box bottomPadding="1">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{EGRID}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="193" y="34" width="300" height="17" isPrintWhenDetailOverflows="true" uuid="925001cf-bf41-4cf2-93c1-bfdd364ee3b5">
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{RealEstate_EGRID}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="0" y="51" width="493" height="17" uuid="57a82758-8513-41cd-b584-28762bf9567a">
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<box bottomPadding="1">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{MunicipalityLabel}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="193" y="51" width="300" height="17" isPrintWhenDetailOverflows="true" uuid="f062a40f-db3d-4cc9-b909-4502a4241086">
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{RealEstate_MunicipalityName} +" (" +$P{RealEstate_MunicipalityCode}+")"]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="0" y="68" width="493" height="17" uuid="011eb8ec-f8fe-4628-aa92-a7f92920e47c">
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<box bottomPadding="1">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{CadastreLabel}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement x="193" y="68" width="300" height="17" isPrintWhenDetailOverflows="true" uuid="6dbf87cf-3873-45ce-835b-b61d82d8a48b">
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[($P{RealEstate_SubunitOfLandRegister}.equals( "" )) ? $R{NoneGiven} : $P{RealEstate_SubunitOfLandRegister}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="0" y="85" width="493" height="17" uuid="35cb9f28-f023-467b-a461-a6cbaf2b75df">
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+					<printWhenExpression><![CDATA[$P{Display_RealEstate_SubunitOfLandRegister}]]></printWhenExpression>
+				</reportElement>
+				<box bottomPadding="1">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{PropertyAreaLabel}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="193" y="85" width="300" height="17" isPrintWhenDetailOverflows="true" uuid="5513d87c-e48d-4932-afb9-c896219dfbc5">
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle" markup="html">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{RealEstate_LandRegistryArea}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="0" y="102" width="493" height="17" uuid="6b10003f-9086-4969-99f1-08f7d9b41b6a">
+					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+				</reportElement>
+				<box bottomPadding="1">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{UpdateDateCSLabel}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="193" y="102" width="300" height="17" uuid="59a85de1-c127-433b-8eeb-efc763a74110">
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{UpdateDateCS}]]></textFieldExpression>
+			</textField>
+		</band>
+	</title>
+</jasperReport>

--- a/print-apps/oereb/mainRealestateInfoNOCadaster.jrxml
+++ b/print-apps/oereb/mainRealestateInfoNOCadaster.jrxml
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.17.0.final using JasperReports Library version 6.17.0-6d93193241dd8cc42629e188b94f9e0bc5722efd  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="topicmapboxlegend" pageWidth="493" pageHeight="102" whenNoDataType="AllSectionsNoDetail" columnWidth="493" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="6477891d-f5c5-456f-a115-e91b2a2768c6">
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
+	<property name="com.jaspersoft.studio.unit." value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.pageWidth" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.topMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.bottomMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.leftMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
+	<style name="Default" isDefault="true" fontName="Cadastra" fontSize="8"/>
+	<parameter name="RealEstate_Number" class="java.lang.String"/>
+	<parameter name="RealEstate_Type_Text" class="java.lang.String"/>
+	<parameter name="RealEstate_EGRID" class="java.lang.String"/>
+	<parameter name="RealEstate_MunicipalityName" class="java.lang.String"/>
+	<parameter name="RealEstate_MunicipalityCode" class="java.lang.String"/>
+	<parameter name="RealEstate_LandRegistryArea" class="java.lang.String"/>
+	<parameter name="RealEstate_SubunitOfLandRegister" class="java.lang.String"/>
+	<parameter name="UpdateDateCS" class="java.lang.String"/>
+	<parameter name="Display_Certification" class="java.lang.Boolean"/>
+	<parameter name="Display_RealEstate_SubunitOfLandRegister" class="java.lang.Boolean"/>
+	<parameter name="SUBREPORT_DIR" class="java.lang.String"/>
+	<title>
+		<band height="102">
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<textField>
+				<reportElement x="0" y="0" width="493" height="17" uuid="fd056aa4-9b94-4ffc-a257-fc931f99e7a8">
+					<property name="com.jaspersoft.studio.unit.x" value="cm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<box bottomPadding="2">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{RealEstateLabel}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="193" y="0" width="300" height="17" uuid="28b56fef-274e-45f3-853c-5d9c52f33f71">
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{RealEstate_Number}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="0" y="17" width="493" height="17" uuid="e8c53976-1abf-4773-8c8b-09c29ecbdfbd">
+					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.width" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+				</reportElement>
+				<box bottomPadding="1">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{RealEstateTypeLabel}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="193" y="17" width="300" height="17" isPrintWhenDetailOverflows="true" uuid="5cfead8a-bdfe-4164-a938-c8829d5f6bc7">
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle" markup="styled">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{RealEstate_Type_Text}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Default" x="0" y="34" width="493" height="17" uuid="006f5580-5e3e-4f4a-a684-b9faa840fdf4">
+					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.width" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<box bottomPadding="1">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{EGRID}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="193" y="34" width="300" height="17" isPrintWhenDetailOverflows="true" uuid="925001cf-bf41-4cf2-93c1-bfdd364ee3b5">
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{RealEstate_EGRID}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="0" y="51" width="493" height="17" uuid="57a82758-8513-41cd-b584-28762bf9567a">
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<box bottomPadding="1">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{MunicipalityLabel}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="193" y="51" width="300" height="17" isPrintWhenDetailOverflows="true" uuid="f062a40f-db3d-4cc9-b909-4502a4241086">
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{RealEstate_MunicipalityName} +" (" +$P{RealEstate_MunicipalityCode}+")"]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="0" y="68" width="493" height="17" uuid="35cb9f28-f023-467b-a461-a6cbaf2b75df">
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+				</reportElement>
+				<box bottomPadding="1">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{PropertyAreaLabel}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="193" y="68" width="300" height="17" isPrintWhenDetailOverflows="true" uuid="5513d87c-e48d-4932-afb9-c896219dfbc5">
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle" markup="html">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{RealEstate_LandRegistryArea}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="0" y="85" width="493" height="17" uuid="6b10003f-9086-4969-99f1-08f7d9b41b6a">
+					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+				</reportElement>
+				<box bottomPadding="1">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{UpdateDateCSLabel}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="193" y="85" width="300" height="17" uuid="59a85de1-c127-433b-8eeb-efc763a74110">
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{UpdateDateCS}]]></textFieldExpression>
+			</textField>
+		</band>
+	</title>
+</jasperReport>

--- a/print-apps/oereb/mainpage.jrxml
+++ b/print-apps/oereb/mainpage.jrxml
@@ -44,33 +44,48 @@
 	<title>
 		<band height="735">
 			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-			<textField>
-				<reportElement x="0" y="472" width="493" height="17" uuid="e6e5ab1e-49d6-4b4b-b852-d5c8e78ff672">
+			<subreport>
+				<reportElement x="0" y="472" width="493" height="120" isPrintWhenDetailOverflows="true" uuid="c2c685e2-6d43-4306-a30d-723a4d260214">
 					<property name="com.jaspersoft.studio.unit.x" value="cm"/>
-					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
 				</reportElement>
-				<box bottomPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Cadastra" size="8" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$R{RealEstateLabel}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="193" y="472" width="300" height="17" uuid="1efcde4f-be46-49d8-8223-297d81bb148b">
-					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
-				</reportElement>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Cadastra" size="8" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{RealEstate_Number}]]></textFieldExpression>
-			</textField>
+				<subreportParameter name="RealEstate_Number">
+					<subreportParameterExpression><![CDATA[$P{RealEstate_Number}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="RealEstate_Type_Text">
+					<subreportParameterExpression><![CDATA[$P{RealEstate_Type_Text}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="RealEstate_EGRID">
+					<subreportParameterExpression><![CDATA[$P{RealEstate_EGRID}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="RealEstate_MunicipalityName">
+					<subreportParameterExpression><![CDATA[$P{RealEstate_MunicipalityName}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="RealEstate_MunicipalityCode">
+					<subreportParameterExpression><![CDATA[$P{RealEstate_MunicipalityCode}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="RealEstate_LandRegistryArea">
+					<subreportParameterExpression><![CDATA[$P{RealEstate_LandRegistryArea}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="RealEstate_SubunitOfLandRegister">
+					<subreportParameterExpression><![CDATA[$P{RealEstate_SubunitOfLandRegister}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="UpdateDateCS">
+					<subreportParameterExpression><![CDATA[$P{UpdateDateCS}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="Display_Certification">
+					<subreportParameterExpression><![CDATA[$P{Display_Certification}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="Display_RealEstate_SubunitOfLandRegister">
+					<subreportParameterExpression><![CDATA[$P{Display_RealEstate_SubunitOfLandRegister}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="REPORT_RESOURCE_BUNDLE">
+					<subreportParameterExpression><![CDATA[$P{REPORT_RESOURCE_BUNDLE}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportExpression><![CDATA[$P{Display_RealEstate_SubunitOfLandRegister} ? "mainRealestateInfo.jasper" : "mainRealestateInfoNOCadaster.jasper"]]></subreportExpression>
+			</subreport>
 			<textField>
 				<reportElement x="0" y="697" width="100" height="12" uuid="e0c1f775-61b3-41c4-a7ec-b8e68adeeb11">
 					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
@@ -102,158 +117,6 @@
 				<textFieldExpression><![CDATA[$P{Certification} + (($P{CertificationAtWeb} == null) ? null : ", <a href='"+$P{CertificationAtWeb}+"' style=\"color:#4C8FBA\">"+$P{CertificationAtWeb}+"</a>")]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="0" y="523" width="493" height="17" uuid="b1be1539-699e-4517-9297-bca1bb7db679">
-					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
-				</reportElement>
-				<box bottomPadding="1">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Cadastra" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$R{MunicipalityLabel}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="0" y="489" width="493" height="17" uuid="f98aab4e-e92d-4173-ae93-8f4b81fa1fd6">
-					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.width" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
-				</reportElement>
-				<box bottomPadding="1">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Cadastra" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$R{RealEstateTypeLabel}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement style="Default" x="0" y="506" width="493" height="17" uuid="f98aab4e-e92d-4173-ae93-8f4b81fa1fd6">
-					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.width" value="mm"/>
-				</reportElement>
-				<box bottomPadding="1">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Cadastra" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$R{EGRID}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="193" y="523" width="300" height="17" uuid="3dcd1a9c-a8a9-427c-bc92-76df18584c3c">
-					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
-				</reportElement>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Cadastra" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{RealEstate_MunicipalityName} +" (" +$P{RealEstate_MunicipalityCode}+")"]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="0" y="574" width="493" height="17" uuid="22ad5f4f-d1eb-4eef-ad76-4458ea1734df">
-					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
-				</reportElement>
-				<box bottomPadding="1">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Cadastra" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$R{UpdateDateCSLabel}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="193" y="540" width="300" height="17" uuid="c4b72298-a4f3-4641-8a67-e39b309c492c">
-					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
-					<printWhenExpression><![CDATA[$P{Display_RealEstate_SubunitOfLandRegister} == false]]></printWhenExpression>
-				</reportElement>
-				<textElement verticalAlignment="Middle" markup="html">
-					<font fontName="Cadastra" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{RealEstate_LandRegistryArea}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="0" y="557" width="493" height="17" uuid="22ad5f4f-d1eb-4eef-ad76-4458ea1734df">
-					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
-					<printWhenExpression><![CDATA[$P{Display_RealEstate_SubunitOfLandRegister}]]></printWhenExpression>
-				</reportElement>
-				<box bottomPadding="1">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Cadastra" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$R{PropertyAreaLabel}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="193" y="557" width="300" height="17" uuid="c4b72298-a4f3-4641-8a67-e39b309c492c">
-					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
-					<printWhenExpression><![CDATA[$P{Display_RealEstate_SubunitOfLandRegister}]]></printWhenExpression>
-				</reportElement>
-				<textElement verticalAlignment="Middle" markup="html">
-					<font fontName="Cadastra" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{RealEstate_LandRegistryArea}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="0" y="540" width="493" height="17" uuid="eea52ed0-9480-42f2-affc-6295ac727898">
-					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
-					<printWhenExpression><![CDATA[$P{Display_RealEstate_SubunitOfLandRegister}]]></printWhenExpression>
-				</reportElement>
-				<box bottomPadding="1">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Cadastra" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$R{CadastreLabel}]]></textFieldExpression>
-			</textField>
-			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement x="193" y="540" width="300" height="17" uuid="21952a7d-f2e7-4421-b1ad-dad328683e6b">
-					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
-					<printWhenExpression><![CDATA[$P{Display_RealEstate_SubunitOfLandRegister}]]></printWhenExpression>
-				</reportElement>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Cadastra" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($P{RealEstate_SubunitOfLandRegister}.equals( "" )) ? $R{NoneGiven} : $P{RealEstate_SubunitOfLandRegister}]]></textFieldExpression>
-			</textField>
-			<textField>
 				<reportElement x="0" y="631" width="493" height="17" uuid="e76937fd-554b-4f00-8ffd-90b86cef8a09">
 					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
 					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
@@ -270,36 +133,6 @@
 					<font fontName="Cadastra" size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$R{CreationDateLabel}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="193" y="489" width="300" height="17" uuid="cf0c5b01-a2a9-4c4f-84f5-c677600e053c">
-					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
-				</reportElement>
-				<textElement verticalAlignment="Middle" markup="styled">
-					<font fontName="Cadastra" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{RealEstate_Type_Text}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="193" y="506" width="300" height="17" uuid="cf0c5b01-a2a9-4c4f-84f5-c677600e053c">
-					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
-				</reportElement>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Cadastra" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{RealEstate_EGRID}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="193" y="574" width="300" height="17" uuid="cf0c5b01-a2a9-4c4f-84f5-c677600e053c">
-					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
-					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
-				</reportElement>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Cadastra" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{UpdateDateCS}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="193" y="631" width="300" height="17" uuid="80f1e41d-de38-4d0b-a5d3-bb27e4c0945e">

--- a/print-apps/oereb/mainpage.jrxml
+++ b/print-apps/oereb/mainpage.jrxml
@@ -255,7 +255,6 @@
 			<subreport>
 				<reportElement stretchType="ContainerBottom" x="0" y="0" width="493" height="55" uuid="5593ce53-3995-4d63-8aaa-ed11b332a8a6">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-					<printWhenExpression><![CDATA[$P{PrintCantonLogo}]]></printWhenExpression>
 				</reportElement>
 				<subreportParameter name="FederalLogoRef">
 					<subreportParameterExpression><![CDATA[$P{FederalLogoRef}]]></subreportParameterExpression>
@@ -272,31 +271,7 @@
 				<subreportParameter name="RealEstate_MunicipalityName">
 					<subreportParameterExpression><![CDATA[$P{RealEstate_MunicipalityName}]]></subreportParameterExpression>
 				</subreportParameter>
-				<subreportExpression><![CDATA["titleAllLogos.jasper"]]></subreportExpression>
-			</subreport>
-			<subreport>
-				<reportElement stretchType="ContainerBottom" x="0" y="0" width="493" height="55" uuid="8d02619a-351b-4959-914a-8765f2f8dd02">
-					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-					<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					<property name="com.jaspersoft.studio.unit.y" value="px"/>
-					<printWhenExpression><![CDATA[!$P{PrintCantonLogo}]]></printWhenExpression>
-				</reportElement>
-				<subreportParameter name="FederalLogoRef">
-					<subreportParameterExpression><![CDATA[$P{FederalLogoRef}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="CantonalLogoRef">
-					<subreportParameterExpression><![CDATA[$P{CantonalLogoRef}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="MunicipalityLogoRef">
-					<subreportParameterExpression><![CDATA[$P{MunicipalityLogoRef}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LogoPLRCadastreRef">
-					<subreportParameterExpression><![CDATA[$P{LogoPLRCadastreRef}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="RealEstate_MunicipalityName">
-					<subreportParameterExpression><![CDATA[$P{RealEstate_MunicipalityName}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportExpression><![CDATA["titleNoCantonLogo.jasper"]]></subreportExpression>
+				<subreportExpression><![CDATA[$P{PrintCantonLogo} ? "titleAllLogos.jasper" : "titleNoCantonLogo.jasper"]]></subreportExpression>
 			</subreport>
 		</band>
 	</title>


### PR DESCRIPTION
This is a second version that fixes #96
A fist one was done in #104 

To test set the parameter `display_real_estate_subunit_of_land_register` in the config of pyramid_oereb to `False`.

@michmuel can you take a look at this and tell me if this works for you?
We still have duplicate code but I am separating it so that it is more readable and reflects what we have already done in other places.

Note this would also close #104