### PR TITLE
Unify use of dashes when no Data

### DIFF
--- a/print-apps/oereb/legalprovision.jrxml
+++ b/print-apps/oereb/legalprovision.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.10.0.final using JasperReports Library version 6.10.0-unknown  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="TocReport" pageWidth="595" pageHeight="842" whenNoDataType="AllSectionsNoDetail" columnWidth="493" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" whenResourceMissingType="Empty" uuid="6e74177b-d551-4a75-ae51-6cdde3f284ce">
+<!-- Created with Jaspersoft Studio version 6.17.0.final using JasperReports Library version 6.17.0-6d93193241dd8cc42629e188b94f9e0bc5722efd  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="TocReport" pageWidth="595" pageHeight="842" whenNoDataType="NoDataSection" columnWidth="493" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" whenResourceMissingType="Empty" uuid="6e74177b-d551-4a75-ae51-6cdde3f284ce">
 	<property name="net.sf.jasperreports.bookmarks.data.source.parameter" value="REPORT_DATA_SOURCE"/>
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
@@ -25,12 +25,31 @@
 	<field name="Title" class="java.lang.String"/>
 	<field name="OfficialNumber" class="java.lang.String"/>
 	<field name="Abbreviation" class="java.lang.String"/>
+	<title>
+		<band height="15">
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<printWhenExpression><![CDATA[$F{Title} == null]]></printWhenExpression>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true" bookmarkLevel="2">
+				<reportElement stretchType="ContainerHeight" x="0" y="0" width="300" height="13" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" forecolor="#000000" uuid="ac337541-88ec-4cd7-9c51-c01cce2c12aa">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+				</reportElement>
+				<box bottomPadding="3"/>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Cadastra" size="8"/>
+					<paragraph lineSpacing="Single"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{NoneGiven}]]></textFieldExpression>
+			</textField>
+		</band>
+	</title>
 	<detail>
 		<band height="14">
 			<property name="local_mesure_unitheight" value="pixel"/>
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
 			<printWhenExpression><![CDATA[$F{Title} != null]]></printWhenExpression>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" bookmarkLevel="2">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true" bookmarkLevel="2">
 				<reportElement stretchType="ContainerHeight" x="0" y="0" width="300" height="13" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" forecolor="#000000" uuid="114a9f86-a715-4eb3-a8a3-5b17bad23c1a">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="local_mesure_unity" value="pixel"/>
@@ -41,11 +60,12 @@
 					<font fontName="Cadastra" size="8"/>
 					<paragraph lineSpacing="Single"/>
 				</textElement>
-				<textFieldExpression><![CDATA[($F{Title}.equals("") || $F{Title} == null ? "-": $F{Title}) + (($F{Abbreviation}.equals("") || $F{Abbreviation} == null) ? "" : " (" + $F{Abbreviation} + ")") + (($F{OfficialNumber}.equals("") || $F{OfficialNumber} == null) ? "" : ", " + $F{OfficialNumber})]]></textFieldExpression>
+				<textFieldExpression><![CDATA[($F{Title}.equals("") || $F{Title} == null ? $R{NoneGiven} : $F{Title}) + (($F{Abbreviation}.equals("") || $F{Abbreviation} == null) ? "" : " (" + $F{Abbreviation} + ")") + (($F{OfficialNumber}.equals("") || $F{OfficialNumber} == null) ? "" : ", " + $F{OfficialNumber})]]></textFieldExpression>
 			</textField>
 		</band>
 		<band height="9">
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<printWhenExpression><![CDATA[$F{Title} != null]]></printWhenExpression>
 			<subreport>
 				<reportElement stretchType="ContainerBottom" mode="Transparent" x="0" y="0" width="300" height="9" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="aea2a6e2-1814-4099-b8e4-6e588177db99">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>

--- a/print-apps/oereb/topiclegend.jrxml
+++ b/print-apps/oereb/topiclegend.jrxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.4.0.final using JasperReports Library version 6.4.1  -->
+<!-- Created with Jaspersoft Studio version 6.17.0.final using JasperReports Library version 6.17.0-6d93193241dd8cc42629e188b94f9e0bc5722efd  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="topiclegend" pageWidth="299" pageHeight="20" columnWidth="273" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="6477891d-f5c5-456f-a115-e91b2a2768c6">
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
 	<parameter name="Geom_Type" class="java.lang.String"/>
@@ -10,9 +10,27 @@
 	<field name="LegendText" class="java.lang.String"/>
 	<field name="PartInPercent" class="java.lang.String"/>
 	<field name="Geom_Type" class="java.lang.String"/>
+	<title>
+		<band height="17">
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<printWhenExpression><![CDATA[$F{LegendText} == null && $F{SymbolRef} == null]]></printWhenExpression>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement x="0" y="0" width="272" height="17" isRemoveLineWhenBlank="true" uuid="20609299-b7ff-42bd-8f3c-718b228ab6a3">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textElement verticalAlignment="Top">
+					<font fontName="Cadastra" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{NoneGiven}]]></textFieldExpression>
+			</textField>
+		</band>
+	</title>
 	<detail>
 		<band height="17" splitType="Stretch">
 			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+			<printWhenExpression><![CDATA[!($F{LegendText} == null && $F{SymbolRef} == null)]]></printWhenExpression>
 			<image onErrorType="Blank">
 				<reportElement x="0" y="2" width="18" height="9" uuid="b9ef005c-0354-4c25-92dc-0121e89d814c">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
@@ -25,7 +43,7 @@
 				</box>
 				<imageExpression><![CDATA[$F{SymbolRef}]]></imageExpression>
 			</image>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="27" y="0" width="174" height="17" uuid="5f9a91b3-6ee9-4982-a8db-35245b462c2a">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
@@ -69,7 +87,7 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$F{NrOfPoints}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="157" y="0" width="143" height="17" uuid="80654d47-cb87-4690-a7ca-82730f9bb384">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>

--- a/print-apps/oereb/topicotherlegend.jrxml
+++ b/print-apps/oereb/topicotherlegend.jrxml
@@ -1,9 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.4.0.final using JasperReports Library version 6.4.1  -->
+<!-- Created with Jaspersoft Studio version 6.17.0.final using JasperReports Library version 6.17.0-6d93193241dd8cc42629e188b94f9e0bc5722efd  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="topicmapboxlegend" pageWidth="299" pageHeight="19" columnWidth="273" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="6477891d-f5c5-456f-a115-e91b2a2768c6">
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
 	<field name="SymbolRef" class="java.lang.String"/>
 	<field name="LegendText" class="java.lang.String"/>
+	<title>
+		<band height="17">
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<printWhenExpression><![CDATA[$F{LegendText} == null && $F{SymbolRef} == null]]></printWhenExpression>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement x="0" y="0" width="272" height="17" isRemoveLineWhenBlank="true" uuid="20609299-b7ff-42bd-8f3c-718b228ab6a3">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textElement verticalAlignment="Top">
+					<font fontName="Cadastra" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{NoneGiven}]]></textFieldExpression>
+			</textField>
+		</band>
+	</title>
 	<detail>
 		<band height="17" splitType="Stretch">
 			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
@@ -21,7 +38,7 @@
 				</box>
 				<imageExpression><![CDATA[$F{SymbolRef}]]></imageExpression>
 			</image>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="27" y="0" width="272" height="17" isRemoveLineWhenBlank="true" uuid="5f9a91b3-6ee9-4982-a8db-35245b462c2a">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
@@ -32,25 +49,6 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$F{LegendText}]]></textFieldExpression>
 			</textField>
-		</band>
-		<band height="15">
-			<staticText>
-				<reportElement isPrintRepeatedValues="false" x="0" y="0" width="300" height="15" isRemoveLineWhenBlank="true" isPrintInFirstWholeBand="true" isPrintWhenDetailOverflows="true" uuid="4364308d-1db8-42dd-adc8-0c80e71c513b">
-					<property name="local_mesure_unitx" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
-					<property name="local_mesure_unity" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
-					<property name="local_mesure_unitheight" value="pixel"/>
-					<printWhenExpression><![CDATA[$F{LegendText} == null && $F{SymbolRef} == null]]></printWhenExpression>
-				</reportElement>
-				<box bottomPadding="3"/>
-				<textElement markup="html">
-					<font fontName="Cadastra" size="8"/>
-				</textElement>
-				<text><![CDATA[&mdash;]]></text>
-			</staticText>
 		</band>
 	</detail>
 </jasperReport>

--- a/print-apps/oereb/topicpage.jrxml
+++ b/print-apps/oereb/topicpage.jrxml
@@ -329,6 +329,9 @@
 					<property name="local_mesure_unitheight" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
+				<subreportParameter name="REPORT_RESOURCE_BUNDLE">
+					<subreportParameterExpression><![CDATA[$P{REPORT_RESOURCE_BUNDLE}]]></subreportParameterExpression>
+				</subreportParameter>
 				<dataSourceExpression><![CDATA[$F{OtherLegendDataSource}]]></dataSourceExpression>
 				<subreportExpression><![CDATA["topicotherlegend.jasper"]]></subreportExpression>
 			</subreport>
@@ -358,6 +361,9 @@
 				</subreportParameter>
 				<subreportParameter name="Theme_Text">
 					<subreportParameterExpression><![CDATA[$F{Theme_Text}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="REPORT_RESOURCE_BUNDLE">
+					<subreportParameterExpression><![CDATA[$P{REPORT_RESOURCE_BUNDLE}]]></subreportParameterExpression>
 				</subreportParameter>
 				<dataSourceExpression><![CDATA[$F{LegalProvisionsDataSource}]]></dataSourceExpression>
 				<subreportExpression><![CDATA["legalprovision.jasper"]]></subreportExpression>
@@ -409,6 +415,9 @@
 				<subreportParameter name="Theme_Text">
 					<subreportParameterExpression><![CDATA[$F{Theme_Text}]]></subreportParameterExpression>
 				</subreportParameter>
+				<subreportParameter name="REPORT_RESOURCE_BUNDLE">
+					<subreportParameterExpression><![CDATA[$P{REPORT_RESOURCE_BUNDLE}]]></subreportParameterExpression>
+				</subreportParameter>
 				<dataSourceExpression><![CDATA[$F{LawsDataSource}]]></dataSourceExpression>
 				<subreportExpression><![CDATA["legalprovision.jasper"]]></subreportExpression>
 			</subreport>
@@ -459,6 +468,9 @@
 				</subreportParameter>
 				<subreportParameter name="Theme_Text">
 					<subreportParameterExpression><![CDATA[$F{Theme_Text}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="REPORT_RESOURCE_BUNDLE">
+					<subreportParameterExpression><![CDATA[$P{REPORT_RESOURCE_BUNDLE}]]></subreportParameterExpression>
 				</subreportParameter>
 				<dataSourceExpression><![CDATA[$F{HintsDataSource}]]></dataSourceExpression>
 				<subreportExpression><![CDATA["legalprovision.jasper"]]></subreportExpression>


### PR DESCRIPTION
fix #99
The templates now use the same dash every where when no data is given. The dash is configured in [Report.properties](https://github.com/openoereb/pyramid_oereb_mfp/blob/master/print-apps/oereb/Report.properties#L29) and needs to be translated. 

@michmuel and/or @voisardf can you:

- should I adapt the RM translation or is there a reason why this is different? https://github.com/openoereb/pyramid_oereb_mfp/blob/master/print-apps/oereb/Report_rm.properties#L30
- can you check if this dash if fine and the templates work? (I do not have use cases for everything)
