### PR TITLE
Make municipality name optional in the output

### DIFF
--- a/print-apps/oereb/config.yaml
+++ b/print-apps/oereb/config.yaml
@@ -64,6 +64,7 @@ templates:
                 default: None
             RealEstate_Type_Text: !string {}
             RealEstate_Canton: !string {}
+            PrintMunicipalityName: !boolean {}
             RealEstate_MunicipalityName: !string {}
             RealEstate_SubunitOfLandRegister: *optStr
             Display_RealEstate_SubunitOfLandRegister: !boolean

--- a/print-apps/oereb/glossar.jrxml
+++ b/print-apps/oereb/glossar.jrxml
@@ -17,6 +17,7 @@
 	<parameter name="MunicipalityLogoRef" class="java.lang.String"/>
 	<parameter name="LogoPLRCadastre" class="java.lang.String"/>
 	<parameter name="LogoPLRCadastreRef" class="java.lang.String"/>
+	<parameter name="PrintMunicipalityName" class="java.lang.Boolean"/>
 	<parameter name="RealEstate_MunicipalityName" class="java.lang.String"/>
 	<parameter name="GlossaryDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<pageHeader>

--- a/print-apps/oereb/glossar.jrxml
+++ b/print-apps/oereb/glossar.jrxml
@@ -43,6 +43,9 @@
 				<subreportParameter name="RealEstate_MunicipalityName">
 					<subreportParameterExpression><![CDATA[$P{RealEstate_MunicipalityName}]]></subreportParameterExpression>
 				</subreportParameter>
+				<subreportParameter name="PrintMunicipalityName">
+					<subreportParameterExpression><![CDATA[$P{PrintMunicipalityName}]]></subreportParameterExpression>
+				</subreportParameter>
 				<subreportExpression><![CDATA["titleAllLogos.jasper"]]></subreportExpression>
 			</subreport>
 			<subreport>

--- a/print-apps/oereb/mainpage.jrxml
+++ b/print-apps/oereb/mainpage.jrxml
@@ -31,6 +31,7 @@
 	<parameter name="RealEstate_Type_Text" class="java.lang.String"/>
 	<parameter name="RealEstate_EGRID" class="java.lang.String"/>
 	<parameter name="RealEstate_MunicipalityName" class="java.lang.String"/>
+        <parameter name="PrintMunicipalityName" class="java.lang.Boolean"/>
 	<parameter name="RealEstate_MunicipalityCode" class="java.lang.String"/>
 	<parameter name="RealEstate_LandRegistryArea" class="java.lang.String"/>
 	<parameter name="RealEstate_SubunitOfLandRegister" class="java.lang.String"/>

--- a/print-apps/oereb/mainpage.jrxml
+++ b/print-apps/oereb/mainpage.jrxml
@@ -31,7 +31,7 @@
 	<parameter name="RealEstate_Type_Text" class="java.lang.String"/>
 	<parameter name="RealEstate_EGRID" class="java.lang.String"/>
 	<parameter name="RealEstate_MunicipalityName" class="java.lang.String"/>
-        <parameter name="PrintMunicipalityName" class="java.lang.Boolean"/>
+	<parameter name="PrintMunicipalityName" class="java.lang.Boolean"/>
 	<parameter name="RealEstate_MunicipalityCode" class="java.lang.String"/>
 	<parameter name="RealEstate_LandRegistryArea" class="java.lang.String"/>
 	<parameter name="RealEstate_SubunitOfLandRegister" class="java.lang.String"/>
@@ -272,6 +272,9 @@
 				</subreportParameter>
 				<subreportParameter name="RealEstate_MunicipalityName">
 					<subreportParameterExpression><![CDATA[$P{RealEstate_MunicipalityName}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="PrintMunicipalityName">
+					<subreportParameterExpression><![CDATA[$P{PrintMunicipalityName}]]></subreportParameterExpression>
 				</subreportParameter>
 				<subreportExpression><![CDATA[$P{PrintCantonLogo} ? "titleAllLogos.jasper" : "titleNoCantonLogo.jasper"]]></subreportExpression>
 			</subreport>

--- a/print-apps/oereb/pdfextract.jrxml
+++ b/print-apps/oereb/pdfextract.jrxml
@@ -149,6 +149,9 @@
 					<subreportParameter name="RealEstate_MunicipalityName">
 						<subreportParameterExpression><![CDATA[$P{RealEstate_MunicipalityName}]]></subreportParameterExpression>
 					</subreportParameter>
+                                        <subreportParameter name="PrintMunicipalityName">
+                                                <subreportParameterExpression><![CDATA[$P{PrintMunicipalityName}]]></subreportParameterExpression>
+                                        </subreportParameter>
 					<subreportParameter name="RealEstate_SubunitOfLandRegister">
 						<subreportParameterExpression><![CDATA[$P{RealEstate_SubunitOfLandRegister}]]></subreportParameterExpression>
 					</subreportParameter>
@@ -233,6 +236,9 @@
 					<subreportParameter name="RealEstate_MunicipalityName">
 						<subreportParameterExpression><![CDATA[$P{RealEstate_MunicipalityName}]]></subreportParameterExpression>
 					</subreportParameter>
+                                        <subreportParameter name="PrintMunicipalityName">
+                                                <subreportParameterExpression><![CDATA[$P{PrintMunicipalityName}]]></subreportParameterExpression>
+                                        </subreportParameter>
 					<subreportParameter name="RealEstate_SubunitOfLandRegister">
 						<subreportParameterExpression><![CDATA[$P{RealEstate_SubunitOfLandRegister}]]></subreportParameterExpression>
 					</subreportParameter>
@@ -339,6 +345,9 @@
 					<subreportParameter name="RealEstate_MunicipalityName">
 						<subreportParameterExpression><![CDATA[$P{RealEstate_MunicipalityName}]]></subreportParameterExpression>
 					</subreportParameter>
+                                        <subreportParameter name="PrintMunicipalityName">
+                                                <subreportParameterExpression><![CDATA[$P{PrintMunicipalityName}]]></subreportParameterExpression>
+                                        </subreportParameter>
 					<subreportParameter name="GlossaryDataSource">
 						<subreportParameterExpression><![CDATA[$P{GlossaryDataSource}]]></subreportParameterExpression>
 					</subreportParameter>
@@ -402,6 +411,9 @@
 				<subreportParameter name="RealEstate_MunicipalityName">
 					<subreportParameterExpression><![CDATA[$P{RealEstate_MunicipalityName}]]></subreportParameterExpression>
 				</subreportParameter>
+                                        <subreportParameter name="PrintMunicipalityName">
+                                                <subreportParameterExpression><![CDATA[$P{PrintMunicipalityName}]]></subreportParameterExpression>
+                                        </subreportParameter>
 				<subreportParameter name="mapSubReport">
 					<subreportParameterExpression><![CDATA[$P{mapSubReport}]]></subreportParameterExpression>
 				</subreportParameter>

--- a/print-apps/oereb/pdfextract.jrxml
+++ b/print-apps/oereb/pdfextract.jrxml
@@ -45,6 +45,7 @@
 	<parameter name="QRCode" class="java.lang.String"/>
 	<parameter name="QRCodeRef" class="java.lang.String"/>
 	<parameter name="RealEstate_IdentDN" class="java.lang.String"/>
+        <parameter name="PrintMunicipalityName" class="java.lang.Boolean"/>
 	<parameter name="RealEstate_MunicipalityName" class="java.lang.String"/>
 	<parameter name="RealEstate_SubunitOfLandRegister" class="java.lang.String"/>
 	<parameter name="Display_RealEstate_SubunitOfLandRegister" class="java.lang.Boolean"/>

--- a/print-apps/oereb/titleAllLogos.jrxml
+++ b/print-apps/oereb/titleAllLogos.jrxml
@@ -6,6 +6,7 @@
 	<parameter name="FederalLogoRef" class="java.lang.String"/>
 	<parameter name="CantonalLogoRef" class="java.lang.String"/>
 	<parameter name="MunicipalityLogoRef" class="java.lang.String"/>
+        <parameter name="PrintMunicipalityName" class="java.lang.Boolean"/>
 	<parameter name="RealEstate_MunicipalityName" class="java.lang.String"/>
 	<parameter name="LogoPLRCadastreRef" class="java.lang.String"/>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String"/>
@@ -51,6 +52,7 @@
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+					<printWhenExpression><![CDATA[$P{PrintMunicipalityName}]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Center">
 					<font fontName="Cadastra" size="6"/>

--- a/print-apps/oereb/titleAllLogos.jrxml
+++ b/print-apps/oereb/titleAllLogos.jrxml
@@ -6,7 +6,7 @@
 	<parameter name="FederalLogoRef" class="java.lang.String"/>
 	<parameter name="CantonalLogoRef" class="java.lang.String"/>
 	<parameter name="MunicipalityLogoRef" class="java.lang.String"/>
-        <parameter name="PrintMunicipalityName" class="java.lang.Boolean"/>
+	<parameter name="PrintMunicipalityName" class="java.lang.Boolean"/>
 	<parameter name="RealEstate_MunicipalityName" class="java.lang.String"/>
 	<parameter name="LogoPLRCadastreRef" class="java.lang.String"/>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String"/>

--- a/print-apps/oereb/titleNoCantonLogo.jrxml
+++ b/print-apps/oereb/titleNoCantonLogo.jrxml
@@ -6,6 +6,7 @@
 	<parameter name="FederalLogoRef" class="java.lang.String"/>
 	<parameter name="CantonalLogoRef" class="java.lang.String"/>
 	<parameter name="MunicipalityLogoRef" class="java.lang.String"/>
+        <parameter name="PrintMunicipalityName" class="java.lang.Boolean"/>
 	<parameter name="RealEstate_MunicipalityName" class="java.lang.String"/>
 	<parameter name="LogoPLRCadastreRef" class="java.lang.String"/>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String"/>
@@ -40,6 +41,7 @@
 					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+                                        <printWhenExpression><![CDATA[$P{PrintMunicipalityName}]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Center">
 					<font fontName="Cadastra" size="6"/>

--- a/print-apps/oereb/toc.jrxml
+++ b/print-apps/oereb/toc.jrxml
@@ -65,7 +65,7 @@
 	<parameter name="QRCodeRef" class="java.lang.String"/>
 	<parameter name="RealEstate_Number" class="java.lang.String"/>
 	<parameter name="RealEstate_EGRID" class="java.lang.String"/>
-        <parameter name="PrintMunicipalityName" class="java.lang.Boolean"/>
+	<parameter name="PrintMunicipalityName" class="java.lang.Boolean"/>
 	<parameter name="RealEstate_MunicipalityName" class="java.lang.String"/>
 	<parameter name="RealEstate_MunicipalityCode" class="java.lang.String"/>
 	<parameter name="RealEstate_LandRegistryArea" class="java.lang.String"/>
@@ -97,6 +97,9 @@
 				</subreportParameter>
 				<subreportParameter name="RealEstate_MunicipalityName">
 					<subreportParameterExpression><![CDATA[$P{RealEstate_MunicipalityName}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="PrintMunicipalityName">
+					<subreportParameterExpression><![CDATA[$P{PrintMunicipalityName}]]></subreportParameterExpression>
 				</subreportParameter>
 				<subreportExpression><![CDATA["titleAllLogos.jasper"]]></subreportExpression>
 			</subreport>

--- a/print-apps/oereb/toc.jrxml
+++ b/print-apps/oereb/toc.jrxml
@@ -65,6 +65,7 @@
 	<parameter name="QRCodeRef" class="java.lang.String"/>
 	<parameter name="RealEstate_Number" class="java.lang.String"/>
 	<parameter name="RealEstate_EGRID" class="java.lang.String"/>
+        <parameter name="PrintMunicipalityName" class="java.lang.Boolean"/>
 	<parameter name="RealEstate_MunicipalityName" class="java.lang.String"/>
 	<parameter name="RealEstate_MunicipalityCode" class="java.lang.String"/>
 	<parameter name="RealEstate_LandRegistryArea" class="java.lang.String"/>

--- a/print-apps/oereb/topicpage.jrxml
+++ b/print-apps/oereb/topicpage.jrxml
@@ -72,6 +72,7 @@
 	<parameter name="LogoPLRCadastreRef" class="java.lang.String"/>
 	<parameter name="PrintCantonLogo" class="java.lang.Boolean"/>
 	<parameter name="RealEstate_PlanForLandRegister" class="java.lang.String"/>
+        <parameter name="PrintMunicipalityName" class="java.lang.Boolean"/>
 	<parameter name="RealEstate_MunicipalityName" class="java.lang.String"/>
 	<parameter name="RealEstate_LandRegistryArea" class="java.lang.String"/>
 	<parameter name="northArrowSubReport" class="java.lang.String"/>

--- a/print-apps/oereb/topicpage.jrxml
+++ b/print-apps/oereb/topicpage.jrxml
@@ -72,7 +72,7 @@
 	<parameter name="LogoPLRCadastreRef" class="java.lang.String"/>
 	<parameter name="PrintCantonLogo" class="java.lang.Boolean"/>
 	<parameter name="RealEstate_PlanForLandRegister" class="java.lang.String"/>
-        <parameter name="PrintMunicipalityName" class="java.lang.Boolean"/>
+	<parameter name="PrintMunicipalityName" class="java.lang.Boolean"/>
 	<parameter name="RealEstate_MunicipalityName" class="java.lang.String"/>
 	<parameter name="RealEstate_LandRegistryArea" class="java.lang.String"/>
 	<parameter name="northArrowSubReport" class="java.lang.String"/>
@@ -117,6 +117,9 @@
 				</subreportParameter>
 				<subreportParameter name="RealEstate_MunicipalityName">
 					<subreportParameterExpression><![CDATA[$P{RealEstate_MunicipalityName}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="PrintMunicipalityName">
+					<subreportParameterExpression><![CDATA[$P{PrintMunicipalityName}]]></subreportParameterExpression>
 				</subreportParameter>
 				<subreportExpression><![CDATA["titleAllLogos.jasper"]]></subreportExpression>
 			</subreport>


### PR DESCRIPTION
Fixes #129 , replaces #130 :
Make municipality name optional in the output.
Must be done simultaneously to https://github.com/openoereb/pyramid_oereb/pull/1703