### PR TITLE
Use 24h system instead of 12h for the pdf name

### DIFF
--- a/print-apps/oereb/config.yaml
+++ b/print-apps/oereb/config.yaml
@@ -6,7 +6,7 @@ defaultToSvg: true
 templates:
     A4 portrait: !template
         reportTemplate: pdfextract.jrxml
-        outputFilename: ${yyyyMMddhhmmss}_extract
+        outputFilename: ${yyyyMMddHHmmss}_extract
         pdfA: true
         attributes:
             CreationDate: !string {}


### PR DESCRIPTION
This changes the name of the pdf used by MFP as follows:
- `20230821152731_extract.pdf` new name
- `20230821032731_extract.pdf` old name
