### PR TITLE
Set MFP image to minor version that works with the current pyramid_oereb master

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   oereb-print:
     networks:
     - print-network
-    image: camptocamp/mapfish_print:3.30
+    image: camptocamp/mapfish_print:3.30.2
     environment:
       PRINT_YAML_MAX_ALIASES: 200
       LOG_LEVEL: INFO


### PR DESCRIPTION
The newest images of MFP are causing an issue when 
Until the issue is addressed in pyramid_oereb I am adding this change so that a image is used which is working with the current master of pyramid_oereb.
This is a temporary fix for #137 

An issue and a PR with a proposal for a fix will follow in pyramid_oereb

NOTE:
The error appears when creating a PDF extract with the following parameter:
```
compute_toc_pages: true
```