### PR TITLE
Print multiple general infos correctly

### DIFF
--- a/print-apps/oereb/general_info_and_disclaimer.jrxml
+++ b/print-apps/oereb/general_info_and_disclaimer.jrxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.17.0.final using JasperReports Library version 6.17.0-6d93193241dd8cc42629e188b94f9e0bc5722efd  -->
+<!-- Created with Jaspersoft Studio version 6.20.5.final using JasperReports Library version 6.20.5-3efcf2e67f959db3888d79f73dde2dbd7acb4f8e  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="topicmapboxlegend" pageWidth="240" pageHeight="39" whenNoDataType="AllSectionsNoDetail" columnWidth="240" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="6477891d-f5c5-456f-a115-e91b2a2768c6">
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
@@ -39,7 +39,10 @@
 				<textFieldExpression><![CDATA[$P{GeneralInformationLabel}]]></textFieldExpression>
 			</textField>
 		</band>
+	</detail>
+	<summary>
 		<band height="22">
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
 			<textField>
 				<reportElement x="0" y="6" width="240" height="8" uuid="b1952a7b-2006-4a21-bf98-8162489e3bac">
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
@@ -65,5 +68,5 @@
 				<textFieldExpression><![CDATA[$P{DisclaimerLandRegister_Content}]]></textFieldExpression>
 			</textField>
 		</band>
-	</detail>
+	</summary>
 </jasperReport>


### PR DESCRIPTION
This chnge avoids having the DisclaimerLandRegister info printed multiple times if there are multiple entries in the GeneralInformation data source